### PR TITLE
Initial unit testing

### DIFF
--- a/unit_tests/ntest_delstop.py
+++ b/unit_tests/ntest_delstop.py
@@ -1,0 +1,10 @@
+import pytest
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+import delstop
+
+def test_delete_stop():
+    my_sentences = ["The quick brown fox", "Jumps over the lazy dog", "I saw the fox"]
+    updated_sentences = delstop(my_sentences)
+    assert updated_sentences == ["quick brown fox", "Jumps lazy dog", "saw fox"]

--- a/unit_tests/test_deltype.py
+++ b/unit_tests/test_deltype.py
@@ -4,9 +4,16 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 from postagger import POSTagger
 
-def remove_types_test():
-    Tagger = POSTagger(["The quick brown fox.", "Jumps over the lazy dog."])
-    Tagger.remove_types(["PUNCT"])
-    assert Tagger.sentences == ["The quick brown fox", "Jumps over the lazy dog"]
+def test_get_sentences():
+    tagger = POSTagger(["The quick brown fox.", "Jumps over the lazy dog."])
+    assert tagger.sentences == ["The quick brown fox.", "Jumps over the lazy dog."]
 
+def test_remove_types():
+    tagger = POSTagger(["The quick brown fox.", "Jumps over the lazy dog."])
+    tagger.remove_types(["PUNCT"])
+    assert tagger.sentences == ["The quick brown fox", "Jumps over the lazy dog"]
 
+def test_keep_types():
+    tagger = POSTagger(["The quick brown fox.", "Jumps over the lazy dog."])
+    tagger.keep_types(["NOUN", "ADJ"])
+    assert tagger.sentences == ["quick brown fox", "lazy dog"]

--- a/unit_tests/test_deltype.py
+++ b/unit_tests/test_deltype.py
@@ -1,0 +1,12 @@
+import pytest
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from postagger import POSTagger
+
+def remove_types_test():
+    Tagger = POSTagger(["The quick brown fox.", "Jumps over the lazy dog."])
+    Tagger.remove_types(["PUNCT"])
+    assert Tagger.sentences == ["The quick brown fox", "Jumps over the lazy dog"]
+
+


### PR DESCRIPTION
## Changes

- Set up pytest
- Added unit tests for delete type (test_deltype.py) and delete stop words (ntest_delstop.py), but since delete stopwords hasn't been implemented yet, the file name for its unit testing has an 'n' in front of it to stop pytest from attempting to run the test and failing


## Notes for future 
- Change ntest_delstop.py to test_delstop.py when the delete stopwords feature has been implemented
- Add more tests :) 