### PR TITLE
Implement keep syntactic heads + topic feature

### DIFF
--- a/README
+++ b/README
@@ -1,11 +1,18 @@
 .
 ├── src/
+│   ├── ContextWindow.py
+│   ├── depparser.py
 │   ├── main.py
 │   ├── postagger.py
+│   ├── SRL.py
 │   ├── utils.py
 ├── examples/
+│   ├── depparser.md
 │   ├── postagger.md
 ├── unit_tests/
+│   ├── ntest_delstop.py
+│   ├── test_deltype.py
+│   ├── test_depparser.py
 ├── data/
 │   ├── 10*
 │   ├── 1000*

--- a/examples/depparser.md
+++ b/examples/depparser.md
@@ -1,0 +1,19 @@
+## Keep syntactic heads in a sentence
+Regardless of the order in which we pass args, depparser will always run first if specified. Dependency parser must run on a full sentence. We define syntactic heads as a parent of a group of words that depend on it. For example, `a quick brown fox` has the syntactic head `fox`. 
+
+### --depparser (-dp)
+#### Delete determiners and punctuation 
+```console
+foo@bar synthetic-query-translation % python3 src/main.py data/10verbose -dp
+
+What advancements intelligence
+create website scratch
+What symptoms flu
+Tell ways improve focus productivity
+What rated restaurants city
+change impact
+What benefits meditation
+recommend book Python programming
+fix faucet
+What ingredients interview
+```

--- a/examples/depparser.md
+++ b/examples/depparser.md
@@ -1,10 +1,10 @@
-## Keep syntactic heads in a sentence
-Regardless of the order in which we pass args, depparser will always run first if specified. Dependency parser must run on a full sentence. We define syntactic heads as a parent of a group of words that depend on it. For example, `a quick brown fox` has the syntactic head `fox`. 
+## Keep syntactic heads or topic using a Dependency Parser 
+Regardless of the order in which we pass args, depparser will always run first if specified. Dependency parser must run on a full sentence. We define syntactic heads as a parent of a group of words that depend on it. For example, `a quick brown fox` has the syntactic head `fox`. We define topic as the object or subject of a sentence. For example, `I eat apple` has the subject `I` and object `apple`. However, the topic will only be subject if object is none. 
 
-### --depparser (-dp)
-#### Delete determiners and punctuation 
+### --synt_heads (-sh)
+#### Keep syntactic heads only 
 ```console
-foo@bar synthetic-query-translation % python3 src/main.py data/10verbose -dp
+foo@bar synthetic-query-translation % python3 src/main.py data/10verbose -sh
 
 What advancements intelligence
 create website scratch
@@ -16,4 +16,37 @@ What benefits meditation
 recommend book Python programming
 fix faucet
 What ingredients interview
+```
+
+### --topic (-t)
+#### Keep topic of the sentence (object or subject) 
+```console
+foo@bar synthetic-query-translation % python3 src/main.py data/10verbose -t
+
+the latest advancements in artificial intelligence
+a website from scratch
+the symptoms of the flu ?
+my focus and productivity
+the top - rated restaurants in my city
+biodiversity
+the benefits of mindfulness meditation
+a good book for learning Python programming
+a leaking faucet
+the key ingredients for a successful job interview
+```
+
+### Keep topic with remove determiners and punctuation 
+```console
+foo@bar synthetic-query-translation % python3 src/main.py data/10verbose -t -dl DET PUNCT
+
+latest advancements in artificial intelligence
+website from scratch
+symptoms of flu
+my focus and productivity
+top rated restaurants in my city
+biodiversity
+benefits of mindfulness meditation
+good book for learning Python programming
+leaking faucet
+key ingredients for successful job interview
 ```

--- a/src/depparser.py
+++ b/src/depparser.py
@@ -23,6 +23,33 @@ class DependencyParser:
                     valid_words.append(sent.words[index].text)
             self.sentences[i] = ' '.join(valid_words)
     
+    def keep_topic(self) -> None:
+        for i, tagger in enumerate(self.taggers): 
+            word_ids = set()
+            queue = []
+            for sent in tagger.sentences: 
+                for word in sent.words:
+                    if word.deprel == 'nsubj':
+                        queue.append(word.id)
+                        word_ids.add(word.id)
+                    if word.deprel == 'obj':
+                        if len(queue) != 0:
+                            queue.pop()        # pop off nsubj
+                            word_ids.pop()
+                        queue.append(word.id)
+                        word_ids.add(word.id)
+                # queue either has nsubj or obj root 
+                assert len(queue) == 1
+                # get all words dependent on root
+                while queue:
+                    word = queue.pop(0)
+                    for child in sent.words:
+                        if child.head == word:
+                            queue.append(child.id)
+                            word_ids.add(child.id)
+            valid_words = [sent.words[index-1].text for index in sorted(word_ids)]
+            self.sentences[i] = ' '.join(valid_words)
+
     def get_sentences(self) -> list[str]:
         """Return the transofrmed sentences."""
         return self.sentences

--- a/src/depparser.py
+++ b/src/depparser.py
@@ -1,0 +1,28 @@
+import stanza
+
+nlp = stanza.Pipeline(lang='en', processors='tokenize,mwt,pos,lemma,depparse')
+
+class DependencyParser: 
+    """A dependency parser for English with capacity to keep syntactic heads."""
+
+    def __init__(self, sentences: list[str]) -> None:
+        """Create dependency parser for the given sentences."""
+        self.sentences = sentences
+        self.taggers = [nlp(sent) for sent in self.sentences]
+
+    def keep_heads(self) -> None:
+        """Keep syntactic heads in order that they appear"""
+        for i, tagger in enumerate(self.taggers): 
+            head_indices = set()
+            valid_words = []
+            for sent in tagger.sentences: 
+                for word in sent.words:
+                    if word.head != 0:
+                        head_indices.add(word.head-1)
+                for index in sorted(head_indices):
+                    valid_words.append(sent.words[index].text)
+            self.sentences[i] = ' '.join(valid_words)
+    
+    def get_sentences(self) -> list[str]:
+        """Return the transofrmed sentences."""
+        return self.sentences

--- a/src/main.py
+++ b/src/main.py
@@ -50,10 +50,16 @@ def parse_args() -> argparse.Namespace:
         action=CustomAction
     )
     parser.add_argument(
-        '-dp',
-        '--depparser', 
+        '-sh',
+        '--synt_heads', 
         action='store_true',
         help='Keep only syntactic heads (words that other words depend on). See https://stanfordnlp.github.io/stanza/depparse.html',
+    )
+    parser.add_argument(
+        '-t',
+        '--topic', 
+        action='store_true',
+        help='Keep only object or subject of a sentence. See https://stanfordnlp.github.io/stanza/depparse.html',
     )
 
     # optionally specify output file name 
@@ -96,10 +102,18 @@ def main():
     # read in sentences and store as list
     sentences = store_sentences(args.input)
 
+    # cannot run both head and topic 
+    assert not (args.synt_heads and args.topic)
+
     # dependency parser must run on initial sentences 
-    if args.depparser: 
+    if args.synt_heads: 
         tagger = DependencyParser(sentences)
         tagger.keep_heads()
+        sentences = tagger.get_sentences()
+
+    if args.topic: 
+        tagger = DependencyParser(sentences)
+        tagger.keep_topic()
         sentences = tagger.get_sentences()
 
     # iterate through parsed arguments in user specified order 

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
+from depparser import DependencyParser
 from postagger import POSTagger
 from utils import CustomAction
 
@@ -47,6 +48,12 @@ def parse_args() -> argparse.Namespace:
         nargs='+', 
         help='List of word types to keep in sentences. See https://universaldependencies.org/u/pos/ for possible types',
         action=CustomAction
+    )
+    parser.add_argument(
+        '-dp',
+        '--depparser', 
+        action='store_true',
+        help='Keep only syntactic heads (words that other words depend on). See https://stanfordnlp.github.io/stanza/depparse.html',
     )
 
     # optionally specify output file name 
@@ -89,21 +96,28 @@ def main():
     # read in sentences and store as list
     sentences = store_sentences(args.input)
 
+    # dependency parser must run on initial sentences 
+    if args.depparser: 
+        tagger = DependencyParser(sentences)
+        tagger.keep_heads()
+        sentences = tagger.get_sentences()
+
     # iterate through parsed arguments in user specified order 
-    for k,v in args.ordered_args:
-        log.debug('This arg is %s %s' % (k, v))
-        # ignore input / logging level args  
-        if k == 'verbose' or k == 'quiet' or k == 'input' or v == None: 
-            continue
-        if k == 'denylist': 
-            tagger = POSTagger(sentences)
-            tagger.remove_types(v)
-            sentences = tagger.get_sentences()
-        if k == 'allowlist': 
-            tagger = POSTagger(sentences)
-            tagger.keep_types(v)
-            sentences = tagger.get_sentences()
-        
+    if 'ordered_args' in args:
+        for k,v in args.ordered_args:
+            log.debug('This arg is %s %s' % (k, v))
+            # ignore input / logging level args  
+            if k == 'verbose' or k == 'quiet' or k == 'input' or v == None: 
+                continue
+            if k == 'denylist': 
+                tagger = POSTagger(sentences)
+                tagger.remove_types(v)
+                sentences = tagger.get_sentences()
+            if k == 'allowlist': 
+                tagger = POSTagger(sentences)
+                tagger.keep_types(v)
+                sentences = tagger.get_sentences()
+
         # TODO: implement each strategy
         # TODO: import each strategy as class 
         # e.g. 

--- a/unit_tests/test_depparser.py
+++ b/unit_tests/test_depparser.py
@@ -1,0 +1,16 @@
+import pytest
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from depparser import DependencyParser
+
+sentence = "The quick brown fox jumps over the lazy dog."
+
+def test_get_sentences():
+    parser = DependencyParser([sentence])
+    assert parser.sentences == ["The quick brown fox jumps over the lazy dog."]
+
+def test_keep_heads():
+    parser = DependencyParser([sentence])
+    parser.keep_heads()
+    assert parser.sentences == ["fox jumps dog"]

--- a/unit_tests/test_depparser.py
+++ b/unit_tests/test_depparser.py
@@ -14,3 +14,8 @@ def test_keep_heads():
     parser = DependencyParser([sentence])
     parser.keep_heads()
     assert parser.sentences == ["fox jumps dog"]
+
+def test_keep_heads():
+    parser = DependencyParser([sentence, "The quick brown fox eats the lazy dog."])
+    parser.keep_topic()
+    assert parser.sentences == ["The quick brown fox", "the lazy dog"]


### PR DESCRIPTION
## Change description
Keep syntactic heads. Related: https://github.com/dylanshih1/synthetic-query-translation/issues/10 https://github.com/dylanshih1/synthetic-query-translation/issues/21
- `src/depparser.py`: defines the DependencyParser class which parses each sentence by labeling dependencies on each word 
  - `keep_heads`: function that keeps syntactic heads (words that have other words depending on it) 
  - `keep_topic`: function that keeps the object or subject of a given sentence 
  - `get_sentences`: function that returns resulting sentences 
- other: 
  - Added example usage of feature in `postagger.md`
  - Added option in CLI 
  - Added unit tests for the new functions 

See file for more details. Feedback appreciated. 

## Note: 
you may need to install stanza: https://pypi.org/project/stanza/